### PR TITLE
Feature/walkin-queue

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -2,7 +2,6 @@ from bson.objectid import ObjectId
 from motor.motor_asyncio import (
     AsyncIOMotorClient as MotorClient,
 )
-import motor.motor_asyncio
 import os
 import asyncio
 
@@ -19,7 +18,12 @@ users_collection = db.get_collection("users")
 
 def site_helper(site) -> dict:
     """Return a dict that contain extracted cursor object."""
-    return {"id": str(site["_id"]), "name": site["name"], "location": site["location"], "capacity": site["capacity"]}
+    return {
+        "id": str(site["_id"]),
+        "name": site["name"],
+        "location": site["location"],
+        "capacity": site["capacity"],
+    }
 
 
 async def retrive_sites():

--- a/app/main.py
+++ b/app/main.py
@@ -10,13 +10,18 @@ tags_metadata = [
     {
         "name": "service site",
         "description": "Service site provides user a queue and vaccine",
-        "name": "reservation",
-        "description": "Users reservation data and rules come from WCG group ",
+    },{
+        "name": "vaccine reservation",
+        "description": "Vaccine reservation",
         "externalDocs": {
             "description": "docs",
             "url": "https://wcg-apis.herokuapp.com/reservation_usage",
         },
-    }
+    },
+    {
+        "name": "authentication",
+        "description": "jwt bearear token authentication"
+    },
 ]
 
 app = FastAPI(

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,8 @@ tags_metadata = [
     {
         "name": "service site",
         "description": "Service site provides user a queue and vaccine",
-    },{
+    },
+    {
         "name": "vaccine reservation",
         "description": "Vaccine reservation",
         "externalDocs": {
@@ -17,10 +18,7 @@ tags_metadata = [
             "url": "https://wcg-apis.herokuapp.com/reservation_usage",
         },
     },
-    {
-        "name": "authentication",
-        "description": "jwt bearear token authentication"
-    },
+    {"name": "authentication", "description": "jwt bearear token authentication"},
 ]
 
 app = FastAPI(
@@ -42,6 +40,7 @@ app.include_router(reservation.router, prefix="/api")
 app.include_router(service_site.router, prefix="/api")
 app.include_router(queue_arranging.router, prefix="/api")
 app.include_router(authentication.router)
+
 
 @app.get("/", include_in_schema=False)
 async def read_root():

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,4 @@
 from fastapi import FastAPI
-
 from app.routers import reservation, service_site, queue_arranging, authentication
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -43,7 +42,6 @@ app.include_router(reservation.router, prefix="/api")
 app.include_router(service_site.router, prefix="/api")
 app.include_router(queue_arranging.router, prefix="/api")
 app.include_router(authentication.router)
-
 
 @app.get("/", include_in_schema=False)
 async def read_root():

--- a/app/models/reservation.py
+++ b/app/models/reservation.py
@@ -60,7 +60,6 @@ example_reservation = {
     },
 }
 
-example_get_reservations = {"response": {
-    "reservations": [example_reservation]}}
+example_get_reservations = {"response": {"reservations": [example_reservation]}}
 
 example_get_reservation = {"reservation": example_reservation}

--- a/app/models/service_site.py
+++ b/app/models/service_site.py
@@ -1,10 +1,11 @@
-from os import lstat
-from typing import List, Dict, Optional
-from pydantic import BaseModel, Extra, create_model
+from typing import Dict
+from pydantic import BaseModel, Extra
+
 
 class Coordinate(BaseModel):
     latitude: float
     longitude: float
+
 
 class Location(BaseModel):
     formatted_address: str

--- a/app/models/service_site.py
+++ b/app/models/service_site.py
@@ -20,6 +20,7 @@ class Location(BaseModel):
 
 
 class Site(BaseModel):
+    id: str
     name: str
     location: Location
     capacity: int

--- a/app/routers/authentication.py
+++ b/app/routers/authentication.py
@@ -12,7 +12,7 @@ from app.utils.oauth2 import get_current_user
 from datetime import timedelta
 from fastapi.security import OAuth2PasswordRequestForm
 
-router = APIRouter(tags=["Authentication"])
+router = APIRouter(tags=["authentication"])
 
 
 @router.post(

--- a/app/routers/authentication.py
+++ b/app/routers/authentication.py
@@ -1,9 +1,7 @@
 from fastapi import APIRouter, Depends, status
 from fastapi.exceptions import HTTPException
-from starlette.routing import request_response
 from app.models.authentication import LoginResponse
 from app.models.basic_model import Message
-from app.models.token import Token
 from app.models.user import User
 from app.database import retrieve_user, retrieve_password
 from app.utils.hashing import Hash
@@ -32,7 +30,7 @@ async def login(request: OAuth2PasswordRequestForm = Depends()):
     - **password** : your valid password.
 
     Keys in the request body are auto-generated from **OAuth2PasswordRequestForm**.
-    """   
+    """
     user = await retrieve_user(request.username)
     if not user:
         raise HTTPException(

--- a/app/routers/queue_arranging.py
+++ b/app/routers/queue_arranging.py
@@ -1,4 +1,6 @@
 from fastapi import APIRouter, Depends
+from fastapi.exceptions import HTTPException
+from starlette.status import HTTP_404_NOT_FOUND
 from app.database import db
 from datetime import datetime, timedelta
 from app.routers import service_site
@@ -8,8 +10,10 @@ from app.utils.oauth2 import get_current_user
 from app.routers.reservation import read_users_reservations
 from app.routers.service_site import read_one_site
 from app.models.basic_model import Message
+from bson.objectid import ObjectId
+from typing import Optional
 
-router = APIRouter(prefix="/site/{site_id}")
+router = APIRouter(prefix="/site/{site_id}/queues", tags=["vaccine reservation"])
 
 time_str = [
     "10:00-10:30",
@@ -25,15 +29,26 @@ time_str = [
 time_format = "%Y/%m/%d"
 
 
-@router.get("/time_slots")
-async def read_time_slots(site_id: str):
+@router.get("/")
+async def read_time_slots(site_id: str, date:Optional[str] = ""):
     """
     ## Retrive Vaccination Queue
+    - **site_id**: a valid service provider site.
+    - **date** : a specific time slot date time string.
     """
     service_site = await read_one_site(site_id)
     all_time_slots = []
-    async for time_slot in db.time_slots.find({"service_site": service_site["response"]["name"]}):
+    async for time_slot in db.time_slots.find({"service_site": service_site.name}):
         all_time_slots.append({**time_slot, "_id": str(time_slot["_id"])})
+
+    if len(all_time_slots) < 1:
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=f"Time slots in {site_id} is not found")
+
+    if date:
+        selected_date = datetime.strptime(date, time_format)
+        for time_slot in all_time_slots:
+            if time_slot["date"] == selected_date:
+                return time_slot
     return {"time_slots": all_time_slots}
 
 
@@ -42,7 +57,6 @@ async def update_queue(site_id: str, current_user: User = Depends(get_current_us
     """
     ## Update Vaccination Queue
     - **site_id**: a valid service provider site.
-
     """
     reservations = (await read_users_reservations(site_id))["response"]["reservations"]
     service_site = await read_one_site(site_id)
@@ -53,7 +67,7 @@ async def update_queue(site_id: str, current_user: User = Depends(get_current_us
     date = datetime.strptime("2021/11/20", time_format)
     all_time_slots.append(
         {
-            "service_site": service_site["response"]["name"],
+            "service_site": service_site.name,
             "time_str": "10:00-10:30",
             "date": "2021/11/20",
             "reservations": []}
@@ -85,3 +99,12 @@ async def update_queue(site_id: str, current_user: User = Depends(get_current_us
     except:
         return Message(message="error occurred during queue updating")
     return Message(message="update queue successfully")
+
+
+@router.delete("/{time_slot_id}", response_model=Message)
+async def destroy_time_slot(site_id: str,time_slot_id:str, current_user: User = Depends(get_current_user)):
+    time_slot = db.time_slots.find_one({"_id": ObjectId(time_slot_id)})
+    if time_slot:
+        await db.time_slots.delete_one({"_id": ObjectId(time_slot_id)})
+        return Message(message=f"remove time slot id {time_slot_id} from site id {site_id} success")
+    raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=f"time slot id {time_slot_id} not found")

--- a/app/routers/queue_arranging.py
+++ b/app/routers/queue_arranging.py
@@ -26,16 +26,24 @@ time_format = "%Y/%m/%d"
 
 
 @router.get("/time_slots")
-async def read_time_slots(site_id: str ):   
+async def read_time_slots(site_id: str):
+    """
+    ## Retrive Vaccination Queue
+    """
     service_site = await read_one_site(site_id)
     all_time_slots = []
-    async for time_slot in db.time_slots.find({}):
+    async for time_slot in db.time_slots.find({"service_site": service_site["response"]["name"]}):
         all_time_slots.append({**time_slot, "_id": str(time_slot["_id"])})
     return {"time_slots": all_time_slots}
 
 
 @router.get("/update_queue", response_model=Message)
 async def update_queue(site_id: str, current_user: User = Depends(get_current_user)):
+    """
+    ## Update Vaccination Queue
+    - **site_id**: a valid service provider site.
+
+    """
     reservations = (await read_users_reservations(site_id))["response"]["reservations"]
     service_site = await read_one_site(site_id)
     all_time_slots = []
@@ -43,12 +51,11 @@ async def update_queue(site_id: str, current_user: User = Depends(get_current_us
     time_str_index = 0
     delta_time = 0
     date = datetime.strptime("2021/11/20", time_format)
-    # print(reservations)
     all_time_slots.append(
         {
             "service_site": service_site["response"]["name"],
-            "time_str": "10:00-10:30", 
-            "date": "2021/11/20", 
+            "time_str": "10:00-10:30",
+            "date": "2021/11/20",
             "reservations": []}
     )
 

--- a/app/routers/queue_arranging.py
+++ b/app/routers/queue_arranging.py
@@ -3,8 +3,6 @@ from fastapi.exceptions import HTTPException
 from starlette.status import HTTP_404_NOT_FOUND
 from app.database import db
 from datetime import datetime, timedelta
-from app.routers import service_site
-from app.utils.sample_reservations import sample_reservations
 from app.models.user import User
 from app.utils.oauth2 import get_current_user
 from app.routers.reservation import read_users_reservations
@@ -13,7 +11,8 @@ from app.models.basic_model import Message
 from bson.objectid import ObjectId
 from typing import Optional
 
-router = APIRouter(prefix="/site/{site_id}/queues", tags=["vaccine reservation"])
+router = APIRouter(
+    prefix="/site/{site_id}/queues", tags=["vaccine reservation"])
 
 time_str = [
     "10:00-10:30",
@@ -30,7 +29,7 @@ time_format = "%Y/%m/%d"
 
 
 @router.get("/")
-async def read_time_slots(site_id: str, date:Optional[str] = ""):
+async def read_time_slots(site_id: str, date: Optional[str] = ""):
     """
     ## Retrive Vaccination Queue
     - **site_id**: a valid service provider site.
@@ -42,7 +41,8 @@ async def read_time_slots(site_id: str, date:Optional[str] = ""):
         all_time_slots.append({**time_slot, "_id": str(time_slot["_id"])})
 
     if len(all_time_slots) < 1:
-        raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=f"Time slots in {site_id} is not found")
+        raise HTTPException(status_code=HTTP_404_NOT_FOUND,
+                            detail=f"Time slots in {site_id} is not found")
 
     if date:
         selected_date = datetime.strptime(date, time_format)
@@ -58,12 +58,14 @@ async def update_queue(site_id: str, current_user: User = Depends(get_current_us
     ## Update Vaccination Queue
     - **site_id**: a valid service provider site.
     """
+
     reservations = (await read_users_reservations(site_id))["response"]["reservations"]
     service_site = await read_one_site(site_id)
     all_time_slots = []
     time_slot_index = 0
     time_str_index = 0
     delta_time = 0
+    time_slot_size = 10
     date = datetime.strptime("2021/11/20", time_format)
     all_time_slots.append(
         {
@@ -72,16 +74,21 @@ async def update_queue(site_id: str, current_user: User = Depends(get_current_us
             "date": "2021/11/20",
             "reservations": []}
     )
-
+    count_reservation = 0
     for reservation in reservations:
-        if len(all_time_slots[time_slot_index]["reservations"]) == 10:
+        if count_reservation == service_site.capacity:
+            break
+        if len(all_time_slots[time_slot_index]["reservations"]) == time_slot_size:
+            queue = (date + timedelta(hours=10, minutes=30)
+                     ).strftime("%Y-%m-%d %H:%M:%S.%f")
+            reservation.update({"queue": queue})
             time_str_index += 1
             if time_str_index == len(time_str):
                 time_str_index = 0
                 delta_time += 1
-
             all_time_slots.append(
                 {
+                    "service_site": service_site.name,
                     "time_str": time_str[time_str_index],
                     "date": (date + timedelta(days=delta_time)).strftime(time_format),
                     "reservations": [reservation],
@@ -91,20 +98,39 @@ async def update_queue(site_id: str, current_user: User = Depends(get_current_us
 
         else:
             all_time_slots[time_slot_index]["reservations"].append(reservation)
-
+        count_reservation += 1
     try:
-        await db.time_slots.delete_many({})
+        async for time_slot in db.time_slots.find({"service_site": service_site.name}):
+            if datetime.strptime(time_slot["date"], time_format) == date:
+                await db.time_slots.delete_many({"service_site": service_site.name, "date": (date + timedelta(days=delta_time)).strftime(time_format)})
         for time_slot in all_time_slots:
             await db.time_slots.insert_one(time_slot)
+        if count_reservation > service_site.capacity:
+            return Message(message=f"service site id {site_id} is full on {date}")
     except:
         return Message(message="error occurred during queue updating")
     return Message(message="update queue successfully")
 
 
 @router.delete("/{time_slot_id}", response_model=Message)
-async def destroy_time_slot(site_id: str,time_slot_id:str, current_user: User = Depends(get_current_user)):
+async def destroy_time_slot(site_id: str, time_slot_id: str, current_user: User = Depends(get_current_user)):
     time_slot = db.time_slots.find_one({"_id": ObjectId(time_slot_id)})
     if time_slot:
         await db.time_slots.delete_one({"_id": ObjectId(time_slot_id)})
         return Message(message=f"remove time slot id {time_slot_id} from site id {site_id} success")
-    raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=f"time slot id {time_slot_id} not found")
+    raise HTTPException(status_code=HTTP_404_NOT_FOUND,
+                        detail=f"time slot id {time_slot_id} not found")
+
+
+@router.get("/walkin")
+async def read_walk_in(site_id: str):
+    service_site = await read_one_site(site_id)
+    count = 0
+    async for time_slot in db.time_slots.find({"service_site": service_site.name}):
+        total_reservation = len(time_slot["reservations"])
+        count += total_reservation
+    return {"response": {
+        "service_site": service_site,
+        "remaning": count - service_site.capacity
+
+    }}

--- a/app/routers/reservation.py
+++ b/app/routers/reservation.py
@@ -17,6 +17,7 @@ from app.models.reservation import (
     example_reservation,
 )
 import bson
+import requests
 
 router = APIRouter(prefix="/site/{site_id}", tags=["vaccine reservation"])
 
@@ -42,7 +43,12 @@ async def read_users_reservations(
     - **limit** : number of users to be shown as a result
     - **page** : number of pages to be shown as a result
     """
-    user_data = fetch_url("https://wcg-apis.herokuapp.com/reservations")
+    res = requests.post("https://wcg-apis-test.herokuapp.com/login", auth=('Chayapol', 'Kp6192649'))
+    print(res.status_code)
+    access_token = res.json()["access_token"]
+    print(access_token)
+
+    user_data = fetch_url("https://wcg-apis.herokuapp.com/reservations", token=access_token)
     user_data_by_site_name = arranging_reservation_by_site_name(user_data)
     try:
         site = await retrieve_site(site_id)
@@ -110,62 +116,3 @@ async def read_users_reservation(
                 if user["citizen_id"] == citizen_id:
                     return {"response": {"reservation": user}}
     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="site name is not found")
-
-
-# @router.delete("/reservation/{citizen_id}")
-# async def users_cancellation(
-#     site_id: str,
-#     citizen_id: str
-# ):
-#     """
-#         Cancelled user vaccination information according to their citizen_id:
-
-#         - **site_id** : a valid service site id
-#         - **citizen_id**: each cancellation must have a citizen_id
-
-#     """
-#     import requests
-#     user_data = fetch_url("https://wcg-apis.herokuapp.com/reservations")
-#     user_data_by_site_name = arranging_reservation_by_site_name(user_data)
-
-#     site = await retrieve_site(site_id)
-#     if site:
-#         search_site = get_service_site_avaliable(
-#             data=user_data_by_site_name, key=site["name"])
-#         if search_site:
-#             user_data_at_site = user_data_by_site_name[search_site]
-#             for user in user_data_at_site:
-#                 if(user["citizen_id"] == citizen_id):
-#                     body = {"citizen_id": citizen_id}
-#                     response = requests.delete(
-#                         "https://wcg-apis.herokuapp.com/reservations", data=body)
-#                     return user
-#     raise HTTPException(status_code=404, detail="citizen id not found")
-
-
-# @router.put("/reservation/{citizen_id}")
-# async def update_reservation(
-#     site_id: str,
-#     citizen_id: str,
-# ):
-#     """
-#         Update user vaccination information according to their citizen_id:
-
-#         - **site_id** : a valid service site id
-#         - **citizen_id**: each cancellation must have a citizen_id
-
-#     """
-#     user_data = fetch_url("https://wcg-apis.herokuapp.com/reservations")
-#     user_data_by_site_name = arranging_reservation_by_site_name(user_data)
-
-#     site = await retrieve_site(site_id)
-#     if site:
-#         search_site = get_service_site_avaliable(
-#             data=user_data_by_site_name, key=site["name"])
-#         if search_site:
-#             user_data_at_site = user_data_by_site_name[search_site]
-#             for user in user_data_at_site:
-#                 if(user["citizen_id"] == citizen_id):
-#                     # TODO update reservation
-#                     return user
-#     raise HTTPException(status_code=404, detail="citizen id not found")

--- a/app/routers/reservation.py
+++ b/app/routers/reservation.py
@@ -18,7 +18,7 @@ from app.models.reservation import (
 )
 import bson
 
-router = APIRouter(prefix="/site/{site_id}", tags=["reservation"])
+router = APIRouter(prefix="/site/{site_id}", tags=["vaccine reservation"])
 
 
 @router.get(

--- a/app/routers/reservation.py
+++ b/app/routers/reservation.py
@@ -46,10 +46,7 @@ async def read_users_reservations(
     res = requests.post(
         "https://wcg-apis-test.herokuapp.com/login", auth=("Chayapol", "Kp6192649")
     )
-    print(res.status_code)
     access_token = res.json()["access_token"]
-    print(access_token)
-
     user_data = fetch_url(
         "https://wcg-apis.herokuapp.com/reservations", token=access_token
     )
@@ -101,7 +98,13 @@ async def read_users_reservation(
     - **citizen_id**: a specific citizen_id
 
     """
-    user_data = fetch_url("https://wcg-apis.herokuapp.com/reservations")
+    res = requests.post(
+        "https://wcg-apis-test.herokuapp.com/login", auth=("Chayapol", "Kp6192649")
+    )
+    access_token = res.json()["access_token"]
+    user_data = fetch_url(
+        "https://wcg-apis.herokuapp.com/reservations", token=access_token
+    )
     user_data_by_site_name = arranging_reservation_by_site_name(user_data)
 
     try:

--- a/app/routers/reservation.py
+++ b/app/routers/reservation.py
@@ -43,12 +43,16 @@ async def read_users_reservations(
     - **limit** : number of users to be shown as a result
     - **page** : number of pages to be shown as a result
     """
-    res = requests.post("https://wcg-apis-test.herokuapp.com/login", auth=('Chayapol', 'Kp6192649'))
+    res = requests.post(
+        "https://wcg-apis-test.herokuapp.com/login", auth=("Chayapol", "Kp6192649")
+    )
     print(res.status_code)
     access_token = res.json()["access_token"]
     print(access_token)
 
-    user_data = fetch_url("https://wcg-apis.herokuapp.com/reservations", token=access_token)
+    user_data = fetch_url(
+        "https://wcg-apis.herokuapp.com/reservations", token=access_token
+    )
     user_data_by_site_name = arranging_reservation_by_site_name(user_data)
     try:
         site = await retrieve_site(site_id)
@@ -115,4 +119,6 @@ async def read_users_reservation(
             for user in user_data_at_site:
                 if user["citizen_id"] == citizen_id:
                     return {"response": {"reservation": user}}
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="site name is not found")
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail="site name is not found"
+    )

--- a/app/routers/service_site.py
+++ b/app/routers/service_site.py
@@ -62,7 +62,9 @@ async def read_one_site(id: str):
     """
     site = await retrieve_site(id)
     if site:
-        return Site(name=site["name"], location=site["location"], capacity=site["capacity"])
+        return Site(
+            name=site["name"], location=site["location"], capacity=site["capacity"]
+        )
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND, detail="service site is not found"
     )

--- a/app/routers/service_site.py
+++ b/app/routers/service_site.py
@@ -63,7 +63,7 @@ async def read_one_site(id: str):
     site = await retrieve_site(id)
     if site:
         return Site(
-            name=site["name"], location=site["location"], capacity=site["capacity"]
+            id =site["id"], name=site["name"], location=site["location"], capacity=site["capacity"]
         )
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND, detail="service site is not found"

--- a/app/tests/test_authentication.py
+++ b/app/tests/test_authentication.py
@@ -9,53 +9,47 @@ class TestAuthentication(asynctest.TestCase):
     async def setUp(self) -> None:
         self.client = TestClient(app)
         self.base_url = "/login"
-        self.read_user_url = '/users/me'
-        self.valid_user = {
-            "username": "Tester",
-            "password": "tester123"
-        }
-        self.invalid_user ={
-            "username": "Faker",
-            "password": "Fakepassword"
-        }
+        self.read_user_url = "/users/me"
+        self.valid_user = {"username": "Tester", "password": "tester123"}
+        self.invalid_user = {"username": "Faker", "password": "Fakepassword"}
 
     async def test_login_with_valid_user(self):
         """Test login the valid user."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.post(f"{self.base_url}", data=self.valid_user)
         self.assertEqual(201, responses.status_code)
-        self.assertIn('access_token', responses.json())
+        self.assertIn("access_token", responses.json())
 
     async def test_login_with_wrong_password(self):
         """Test login with valid user but wrong password."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            self.valid_user['password'] = 'Wrong password'
+            self.valid_user["password"] = "Wrong password"
             responses = await ac.post(f"{self.base_url}", data=self.valid_user)
         self.assertEqual(404, responses.status_code)
-        self.assertEqual("Incorrect password", responses.json()['detail'])
+        self.assertEqual("Incorrect password", responses.json()["detail"])
 
     async def test_login_missing_username(self):
         """Test login without username."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            del self.valid_user['username']
+            del self.valid_user["username"]
             responses = await ac.post(f"{self.base_url}", data=self.valid_user)
         self.assertEqual(422, responses.status_code)
-        self.assertEqual(responses.json()['detail'][0]['loc'], ['body', 'username'])
-    
+        self.assertEqual(responses.json()["detail"][0]["loc"], ["body", "username"])
+
     async def test_login_missing_password(self):
         """Test login without password."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
-            del self.valid_user['password']
+            del self.valid_user["password"]
             responses = await ac.post(f"{self.base_url}", data=self.valid_user)
         self.assertEqual(422, responses.status_code)
-        self.assertEqual(responses.json()['detail'][0]['loc'], ['body', 'password'])
+        self.assertEqual(responses.json()["detail"][0]["loc"], ["body", "password"])
 
     async def test_login_with_invalid_user(self):
         """Test login the invalid user."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.post(f"{self.base_url}", data=self.invalid_user)
         self.assertEqual(404, responses.status_code)
-        self.assertEqual("Invalid Credentials", responses.json()['detail'])
+        self.assertEqual("Invalid Credentials", responses.json()["detail"])
 
     @skip("Not complete")
     async def test_read_user_when_login(self):
@@ -65,7 +59,7 @@ class TestAuthentication(asynctest.TestCase):
             responses = await ac.get(f"{self.read_user_url}")
         self.assertEqual(200, responses.status_code)
         self.assertEqual("", responses.text)
-    
+
     @skip("Not complete")
     async def test_read_user_without_login(self):
         """Test get current user witout login."""
@@ -73,9 +67,3 @@ class TestAuthentication(asynctest.TestCase):
             responses = await ac.get(f"{self.read_user_url}")
         self.assertEqual(404, responses.status_code)
         self.assertEqual("", responses.json())
-
-
-
-
-
-

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -4,7 +4,8 @@ from ..main import app
 
 client = TestClient(app)
 
+
 def test_read_main():
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == {'message': 'hello from OGYH'}
+    assert response.json() == {"message": "hello from OGYH"}

--- a/app/tests/test_reservation.py
+++ b/app/tests/test_reservation.py
@@ -23,6 +23,10 @@ class TestReservation(asynctest.TestCase):
                 "vaccine_name": "Astra",
             },
         )
+        res = requests.post(
+            "https://wcg-apis-test.herokuapp.com/login", auth=("Chayapol", "Kp6192649")
+        )
+        self.access_token = res.json()["access_token"]
 
     async def setUp(self) -> None:
         self.queue = asyncio.Queue(maxsize=1)
@@ -45,7 +49,7 @@ class TestReservation(asynctest.TestCase):
         """Test retrive all the valid reservation."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.get(
-                f"{self.base_url}/site/{self.site_id}/reservations"
+                f"{self.base_url}/site/{self.site_id}/reservations", headers={"Authorization": "Bearer {}".format(self.access_token)}
             )
             self.assertEqual(200, responses.status_code)
 
@@ -54,7 +58,7 @@ class TestReservation(asynctest.TestCase):
         page = {"limit": 10, "page": 1}
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.get(
-                f"{self.base_url}/site/{self.site_id}/reservations", params=page
+                f"{self.base_url}/site/{self.site_id}/reservations", params=page, headers={"Authorization": "Bearer {}".format(self.access_token)}
             )
             self.assertEqual(200, responses.status_code)
             content = responses.json()["response"]
@@ -68,7 +72,7 @@ class TestReservation(asynctest.TestCase):
         }  # the negative would be convert to 0 automatically
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.get(
-                f"{self.base_url}/site/{self.site_id}/reservations", params=page
+                f"{self.base_url}/site/{self.site_id}/reservations", params=page, headers={"Authorization": "Bearer {}".format(self.access_token)}
             )
             self.assertEqual(200, responses.status_code)
             content = responses.json()["response"]
@@ -79,7 +83,7 @@ class TestReservation(asynctest.TestCase):
         citizen_id = self.citizen["citizen_id"]
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.get(
-                f"{self.base_url}/site/{self.site_id}/reservation/{citizen_id}"
+                f"{self.base_url}/site/{self.site_id}/reservation/{citizen_id}", headers={"Authorization": "Bearer {}".format(self.access_token)}
             )
             self.assertEqual(200, responses.status_code)
 
@@ -88,7 +92,7 @@ class TestReservation(asynctest.TestCase):
         citizen_id = "11034031341243"
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.get(
-                f"{self.base_url}/site/{self.site_id}/reservation/{citizen_id}"
+                f"{self.base_url}/site/{self.site_id}/reservation/{citizen_id}", headers={"Authorization": "Bearer {}".format(self.access_token)}
             )
             self.assertEqual(404, responses.status_code)
 
@@ -98,7 +102,7 @@ class TestReservation(asynctest.TestCase):
         service_site = "111111111111111111111111"
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.get(
-                f"{self.base_url}/site/{service_site}/reservation/{citizen_id}"
+                f"{self.base_url}/site/{service_site}/reservation/{citizen_id}", headers={"Authorization": "Bearer {}".format(self.access_token)}
             )
             content = responses.json()
             self.assertEqual(404, responses.status_code)
@@ -109,7 +113,7 @@ class TestReservation(asynctest.TestCase):
         service_site = "111111111111111111111111"
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.get(
-                f"{self.base_url}/site/{service_site}/reservations"
+                f"{self.base_url}/site/{service_site}/reservations", headers={"Authorization": "Bearer {}".format(self.access_token)}
             )
             self.assertEqual(404, responses.status_code)
 
@@ -118,7 +122,7 @@ class TestReservation(asynctest.TestCase):
         service_site = "6179113760e255455240052b"
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.get(
-                f"{self.base_url}/site/{service_site}/reservations"
+                f"{self.base_url}/site/{service_site}/reservations", headers={"Authorization": "Bearer {}".format(self.access_token)}
             )
             content = responses.json()
             self.assertEqual(

--- a/app/tests/test_service_site.py
+++ b/app/tests/test_service_site.py
@@ -1,19 +1,14 @@
-from unittest.case import skip
 from ..main import app
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 from app.utils.oauth2 import get_current_user
 import bson
 import requests_mock
-import json
 import asynctest
 
 
 def override_get_current_user():
-    valid_user = {
-        "username": "Tester",
-        "password": "tester123"
-    }
+    valid_user = {"username": "Tester", "password": "tester123"}
     return valid_user
 
 
@@ -25,10 +20,7 @@ class TestServiceSite(asynctest.TestCase):
         self.client = TestClient(app)
         self.base_url = "/api"
         self.auth_url = "/login"
-        self.valid_user = {
-            "username": "Tester",
-            "password": "tester123"
-        }
+        self.valid_user = {"username": "Tester", "password": "tester123"}
         self.valid_service_site = {
             "name": "สถานีกลางบางซื่อ",
             "location": {
@@ -37,12 +29,9 @@ class TestServiceSite(asynctest.TestCase):
                 "postal": "10900",
                 "route": "เทอดดำริ",
                 "city": "กรุงเทพมหานคร",
-                "coordinates": {
-                        "latitude": 13.80375,
-                        "longitude": 100.54225
-                }
+                "coordinates": {"latitude": 13.80375, "longitude": 100.54225},
             },
-            "capacity": 20000
+            "capacity": 20000,
         }
         self.valid_site_id = "619f82fe7d68e527d7763c59"
 
@@ -74,17 +63,16 @@ class TestServiceSite(asynctest.TestCase):
                 "postal": "11140",
                 "route": "กาญจนาภิเษก",
                 "city": "นนทบุรี ",
-                "coordinates": {
-                        "latitude": 13.87719,
-                        "longitude": 100.41136
-                }
+                "coordinates": {"latitude": 13.87719, "longitude": 100.41136},
             },
-            "capacity": 5000
+            "capacity": 5000,
         }
         with requests_mock.Mocker() as rm:
             rm.post(f"{self.base_url}/site", json=valid_service_site)
             async with AsyncClient(app=app, base_url="http://test") as ac:
-                response = await ac.post(f"{self.base_url}/site", json=valid_service_site)
+                response = await ac.post(
+                    f"{self.base_url}/site", json=valid_service_site
+                )
                 self.assertEqual(201, response.status_code)
 
     async def test_insert_service_site_with_invalid_data(self):
@@ -105,15 +93,14 @@ class TestServiceSite(asynctest.TestCase):
             )
             self.assertEqual(200, responses.status_code)
             responses = await ac.get(f"{self.base_url}/site/{self.valid_site_id}")
-            self.assertEqual(
-                self.valid_service_site, responses.json()
-            )
+            self.assertEqual(self.valid_service_site, responses.json())
 
     async def test_update_invalid_service_site(self):
         """Test updated invalid service site using mock request_mock."""
         async with AsyncClient(app=app, base_url="http://test") as ac:
             responses = await ac.put(
-                f"{self.base_url}/site/619f7c3289c2942b7d28f5e1", json=self.valid_service_site
+                f"{self.base_url}/site/619f7c3289c2942b7d28f5e1",
+                json=self.valid_service_site,
             )
             self.assertEqual(404, responses.status_code)
 
@@ -122,9 +109,7 @@ class TestServiceSite(asynctest.TestCase):
         async with AsyncClient(app=app, base_url="http://test") as ac:
             with requests_mock.Mocker() as rm:
                 rm.post(f"{self.base_url}/site", json=self.valid_service_site)
-                rm.delete(
-                    f"{self.base_url}/site/{self.valid_site_id}"
-                )
+                rm.delete(f"{self.base_url}/site/{self.valid_site_id}")
 
     async def test_remove_invalid_12_byte_hex_service_site_id(self):
         """Test remove invalid service site using its id which is 24 characters."""

--- a/app/tests/test_utils.py
+++ b/app/tests/test_utils.py
@@ -4,7 +4,6 @@ import unittest
 
 
 class TestUtils(unittest.TestCase):
-
     def test_fetch_url(self):
         """Test fetch url from the given url"""
         URL = "https://wcg-apis.herokuapp.com/reservations"
@@ -17,6 +16,5 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(list, type(res))
 
     def test_arraging_reservation(self):
-        reservations = utils.arranging_reservation_by_site_name(
-            sample_reservations)
+        reservations = utils.arranging_reservation_by_site_name(sample_reservations)
         self.assertNotEqual(reservations, sample_reservations)

--- a/app/utils/oauth2.py
+++ b/app/utils/oauth2.py
@@ -1,5 +1,5 @@
 from fastapi import Depends, status, HTTPException
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from fastapi.security import OAuth2PasswordBearer
 from app.utils.token import verify_token
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")

--- a/app/utils/paginator.py
+++ b/app/utils/paginator.py
@@ -3,13 +3,9 @@ import math
 
 
 class Paginator:
-
     def __init__(self, items: List) -> None:
         self.__items = items
-        self.__page_data = {
-            "total": len(self.__items),
-            "page": 1
-        }
+        self.__page_data = {"total": len(self.__items), "page": 1}
         self.__start_index = 0
         self.__end_index = len(self.__items)
 
@@ -26,4 +22,4 @@ class Paginator:
         return self.__page_data
 
     def get_items(self):
-        return self.__items[self.__start_index:self.__end_index]
+        return self.__items[self.__start_index : self.__end_index]

--- a/app/utils/sample_reservations.py
+++ b/app/utils/sample_reservations.py
@@ -8,14 +8,13 @@ sample_reservations = [
             "name": "Elizabeth",
             "occupation": "hard support",
             "surname": "Reid",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610252054,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610252054,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1360190500,
         "citizen_data": {
             "address": "house",
@@ -24,14 +23,13 @@ sample_reservations = [
             "name": "Rachel",
             "occupation": "midlane",
             "surname": "Neal",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610039756,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610039756,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1580121369,
         "citizen_data": {
             "address": "house",
@@ -40,14 +38,13 @@ sample_reservations = [
             "name": "Carlos",
             "occupation": "hard support",
             "surname": "Luna",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609954711,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609954711,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1975096558,
         "citizen_data": {
             "address": "house",
@@ -56,14 +53,13 @@ sample_reservations = [
             "name": "Joshua",
             "occupation": "carry",
             "surname": "Brewer",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610270887,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610270887,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1576343463,
         "citizen_data": {
             "address": "house",
@@ -72,14 +68,13 @@ sample_reservations = [
             "name": "Katie",
             "occupation": "hard support",
             "surname": "Orozco",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610230480,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610230480,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1043113469,
         "citizen_data": {
             "address": "house",
@@ -88,14 +83,13 @@ sample_reservations = [
             "name": "Eric",
             "occupation": "soft support",
             "surname": "Marshall",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609742574,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609742574,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1752803929,
         "citizen_data": {
             "address": "house",
@@ -104,14 +98,13 @@ sample_reservations = [
             "name": "Matthew",
             "occupation": "offlane",
             "surname": "Callahan",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609741986,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609741986,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1321967870,
         "citizen_data": {
             "address": "house",
@@ -120,14 +113,13 @@ sample_reservations = [
             "name": "Jennifer",
             "occupation": "midlane",
             "surname": "Gonzalez",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609995179,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609995179,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1577056798,
         "citizen_data": {
             "address": "house",
@@ -136,14 +128,13 @@ sample_reservations = [
             "name": "Carlos",
             "occupation": "soft support",
             "surname": "Luna",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610184049,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610184049,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1971490240,
         "citizen_data": {
             "address": "house",
@@ -152,14 +143,13 @@ sample_reservations = [
             "name": "Mathew",
             "occupation": "hard support",
             "surname": "Brown",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610128377,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610128377,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1226118760,
         "citizen_data": {
             "address": "house",
@@ -168,14 +158,13 @@ sample_reservations = [
             "name": "Christopher",
             "occupation": "carry",
             "surname": "Price",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610056405,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610056405,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1600712459,
         "citizen_data": {
             "address": "house",
@@ -184,14 +173,13 @@ sample_reservations = [
             "name": "Juan",
             "occupation": "hard support",
             "surname": "Ibarra",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610427250,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610427250,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1552777884,
         "citizen_data": {
             "address": "house",
@@ -200,14 +188,13 @@ sample_reservations = [
             "name": "Russell",
             "occupation": "carry",
             "surname": "Pena",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609846800,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609846800,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1804393900,
         "citizen_data": {
             "address": "house",
@@ -216,14 +203,13 @@ sample_reservations = [
             "name": "Ronnie",
             "occupation": "hard support",
             "surname": "Wolfe",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610421855,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610421855,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1468508253,
         "citizen_data": {
             "address": "house",
@@ -232,14 +218,13 @@ sample_reservations = [
             "name": "Mary",
             "occupation": "offlane",
             "surname": "Finley",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609753511,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609753511,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1439318908,
         "citizen_data": {
             "address": "house",
@@ -248,14 +233,13 @@ sample_reservations = [
             "name": "John",
             "occupation": "soft support",
             "surname": "Houston",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610199402,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610199402,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1274417254,
         "citizen_data": {
             "address": "house",
@@ -264,14 +248,13 @@ sample_reservations = [
             "name": "Krystal",
             "occupation": "soft support",
             "surname": "Anderson",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609797074,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609797074,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1472644519,
         "citizen_data": {
             "address": "house",
@@ -280,14 +263,13 @@ sample_reservations = [
             "name": "Randy",
             "occupation": "carry",
             "surname": "Young",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609916237,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609916237,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1989593168,
         "citizen_data": {
             "address": "house",
@@ -296,14 +278,13 @@ sample_reservations = [
             "name": "Brandon",
             "occupation": "soft support",
             "surname": "Soto",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609896810,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609896810,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1114338824,
         "citizen_data": {
             "address": "house",
@@ -312,14 +293,13 @@ sample_reservations = [
             "name": "Nicholas",
             "occupation": "carry",
             "surname": "Walker",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610262506,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610262506,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1362825641,
         "citizen_data": {
             "address": "house",
@@ -328,14 +308,13 @@ sample_reservations = [
             "name": "Justin",
             "occupation": "carry",
             "surname": "Rodgers",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610356962,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610356962,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1154816092,
         "citizen_data": {
             "address": "house",
@@ -344,14 +323,13 @@ sample_reservations = [
             "name": "Brian",
             "occupation": "hard support",
             "surname": "Ryan",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610408595,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610408595,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1032455806,
         "citizen_data": {
             "address": "house",
@@ -360,14 +338,13 @@ sample_reservations = [
             "name": "Christopher",
             "occupation": "offlane",
             "surname": "Moran",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610110904,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610110904,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1912217200,
         "citizen_data": {
             "address": "house",
@@ -376,14 +353,13 @@ sample_reservations = [
             "name": "Amy",
             "occupation": "midlane",
             "surname": "Hull",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610272142,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610272142,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1687188072,
         "citizen_data": {
             "address": "house",
@@ -392,14 +368,13 @@ sample_reservations = [
             "name": "Maria",
             "occupation": "midlane",
             "surname": "Merritt",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609959954,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609959954,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1037816769,
         "citizen_data": {
             "address": "house",
@@ -408,14 +383,13 @@ sample_reservations = [
             "name": "Nathaniel",
             "occupation": "soft support",
             "surname": "Owen",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610416984,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610416984,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1360636557,
         "citizen_data": {
             "address": "house",
@@ -424,14 +398,13 @@ sample_reservations = [
             "name": "Heather",
             "occupation": "carry",
             "surname": "Smith",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610172148,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610172148,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1911595592,
         "citizen_data": {
             "address": "house",
@@ -440,14 +413,13 @@ sample_reservations = [
             "name": "Nicholas",
             "occupation": "hard support",
             "surname": "Mendoza",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610429701,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610429701,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1356614844,
         "citizen_data": {
             "address": "house",
@@ -456,14 +428,13 @@ sample_reservations = [
             "name": "Nichole",
             "occupation": "carry",
             "surname": "Gentry",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610371622,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610371622,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1543146068,
         "citizen_data": {
             "address": "house",
@@ -472,14 +443,13 @@ sample_reservations = [
             "name": "Heather",
             "occupation": "hard support",
             "surname": "Schmidt",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610036313,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610036313,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1301962693,
         "citizen_data": {
             "address": "house",
@@ -488,14 +458,13 @@ sample_reservations = [
             "name": "David",
             "occupation": "carry",
             "surname": "Moore",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610307162,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610307162,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1588419957,
         "citizen_data": {
             "address": "house",
@@ -504,14 +473,13 @@ sample_reservations = [
             "name": "Matthew",
             "occupation": "hard support",
             "surname": "Hughes",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610016469,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610016469,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1853261835,
         "citizen_data": {
             "address": "house",
@@ -520,14 +488,13 @@ sample_reservations = [
             "name": "Robert",
             "occupation": "soft support",
             "surname": "Welch",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610298181,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610298181,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1292038410,
         "citizen_data": {
             "address": "house",
@@ -536,14 +503,13 @@ sample_reservations = [
             "name": "Zachary",
             "occupation": "carry",
             "surname": "Todd",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609814224,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609814224,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1018923012,
         "citizen_data": {
             "address": "house",
@@ -552,14 +518,13 @@ sample_reservations = [
             "name": "Michael",
             "occupation": "offlane",
             "surname": "Allen",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610267417,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610267417,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1768544055,
         "citizen_data": {
             "address": "house",
@@ -568,14 +533,13 @@ sample_reservations = [
             "name": "Kevin",
             "occupation": "soft support",
             "surname": "Richardson",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610330601,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610330601,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1569675917,
         "citizen_data": {
             "address": "house",
@@ -584,14 +548,13 @@ sample_reservations = [
             "name": "Christina",
             "occupation": "hard support",
             "surname": "Smith",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610098268,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610098268,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1695035775,
         "citizen_data": {
             "address": "house",
@@ -600,14 +563,13 @@ sample_reservations = [
             "name": "Jennifer",
             "occupation": "hard support",
             "surname": "Lowe",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610258495,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610258495,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1088241913,
         "citizen_data": {
             "address": "house",
@@ -616,14 +578,13 @@ sample_reservations = [
             "name": "Tina",
             "occupation": "carry",
             "surname": "Howard",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610114924,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610114924,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1747879793,
         "citizen_data": {
             "address": "house",
@@ -632,14 +593,13 @@ sample_reservations = [
             "name": "Bethany",
             "occupation": "carry",
             "surname": "Sanchez",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610402379,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610402379,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1360416578,
         "citizen_data": {
             "address": "house",
@@ -648,14 +608,13 @@ sample_reservations = [
             "name": "Bobby",
             "occupation": "offlane",
             "surname": "Greer",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609853962,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609853962,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1100960747,
         "citizen_data": {
             "address": "house",
@@ -664,14 +623,13 @@ sample_reservations = [
             "name": "Mark",
             "occupation": "midlane",
             "surname": "Sharp",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609856128,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609856128,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1168572604,
         "citizen_data": {
             "address": "house",
@@ -680,14 +638,13 @@ sample_reservations = [
             "name": "William",
             "occupation": "midlane",
             "surname": "Ford",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610345071,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610345071,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1844940259,
         "citizen_data": {
             "address": "house",
@@ -696,14 +653,13 @@ sample_reservations = [
             "name": "Jonathan",
             "occupation": "midlane",
             "surname": "Miller",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609785718,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609785718,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1472492351,
         "citizen_data": {
             "address": "house",
@@ -712,14 +668,13 @@ sample_reservations = [
             "name": "Edward",
             "occupation": "offlane",
             "surname": "Vega",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610072877,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610072877,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1540447228,
         "citizen_data": {
             "address": "house",
@@ -728,14 +683,13 @@ sample_reservations = [
             "name": "Haley",
             "occupation": "hard support",
             "surname": "Finley",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610238645,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610238645,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1186611877,
         "citizen_data": {
             "address": "house",
@@ -744,14 +698,13 @@ sample_reservations = [
             "name": "Logan",
             "occupation": "soft support",
             "surname": "Mcclain",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609781316,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609781316,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1105983326,
         "citizen_data": {
             "address": "house",
@@ -760,14 +713,13 @@ sample_reservations = [
             "name": "Carmen",
             "occupation": "midlane",
             "surname": "Phillips",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610351685,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610351685,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1763692510,
         "citizen_data": {
             "address": "house",
@@ -776,14 +728,13 @@ sample_reservations = [
             "name": "Rachel",
             "occupation": "carry",
             "surname": "Blair",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609916881,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609916881,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1738184331,
         "citizen_data": {
             "address": "house",
@@ -792,14 +743,13 @@ sample_reservations = [
             "name": "Kevin",
             "occupation": "offlane",
             "surname": "Smith",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609931831,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609931831,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1033760400,
         "citizen_data": {
             "address": "house",
@@ -808,14 +758,13 @@ sample_reservations = [
             "name": "Jay",
             "occupation": "carry",
             "surname": "Mcdonald",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610010169,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610010169,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1036724503,
         "citizen_data": {
             "address": "house",
@@ -824,14 +773,13 @@ sample_reservations = [
             "name": "Christian",
             "occupation": "soft support",
             "surname": "Harrison",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610306170,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610306170,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1050120862,
         "citizen_data": {
             "address": "house",
@@ -840,14 +788,13 @@ sample_reservations = [
             "name": "Kaylee",
             "occupation": "offlane",
             "surname": "Stewart",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609840800,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609840800,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1992449610,
         "citizen_data": {
             "address": "house",
@@ -856,14 +803,13 @@ sample_reservations = [
             "name": "Mary",
             "occupation": "hard support",
             "surname": "Evans",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610074963,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610074963,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1070331729,
         "citizen_data": {
             "address": "house",
@@ -872,14 +818,13 @@ sample_reservations = [
             "name": "Charlene",
             "occupation": "offlane",
             "surname": "Greene",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609796220,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609796220,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1611348314,
         "citizen_data": {
             "address": "house",
@@ -888,14 +833,13 @@ sample_reservations = [
             "name": "Jennifer",
             "occupation": "midlane",
             "surname": "Richardson",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610216432,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610216432,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1546150392,
         "citizen_data": {
             "address": "house",
@@ -904,14 +848,13 @@ sample_reservations = [
             "name": "Carlos",
             "occupation": "offlane",
             "surname": "Barnes",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610392496,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610392496,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1163031784,
         "citizen_data": {
             "address": "house",
@@ -920,14 +863,13 @@ sample_reservations = [
             "name": "Daisy",
             "occupation": "soft support",
             "surname": "Jackson",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610269649,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610269649,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1971806813,
         "citizen_data": {
             "address": "house",
@@ -936,14 +878,13 @@ sample_reservations = [
             "name": "Tara",
             "occupation": "midlane",
             "surname": "Johnson",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609915709,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609915709,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1904910486,
         "citizen_data": {
             "address": "house",
@@ -952,14 +893,13 @@ sample_reservations = [
             "name": "Mindy",
             "occupation": "hard support",
             "surname": "Jarvis",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610271088,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610271088,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1231407063,
         "citizen_data": {
             "address": "house",
@@ -968,14 +908,13 @@ sample_reservations = [
             "name": "Kelsey",
             "occupation": "hard support",
             "surname": "Anderson",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609932580,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609932580,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1038489883,
         "citizen_data": {
             "address": "house",
@@ -984,14 +923,13 @@ sample_reservations = [
             "name": "Melissa",
             "occupation": "soft support",
             "surname": "Johnson",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609737168,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609737168,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1746425904,
         "citizen_data": {
             "address": "house",
@@ -1000,14 +938,13 @@ sample_reservations = [
             "name": "Sydney",
             "occupation": "hard support",
             "surname": "Perez",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609969454,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609969454,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1453139903,
         "citizen_data": {
             "address": "house",
@@ -1016,14 +953,13 @@ sample_reservations = [
             "name": "Daniel",
             "occupation": "hard support",
             "surname": "Fernandez",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609922499,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609922499,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1106091755,
         "citizen_data": {
             "address": "house",
@@ -1032,14 +968,13 @@ sample_reservations = [
             "name": "Tamara",
             "occupation": "carry",
             "surname": "Bowman",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610253254,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610253254,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1691809691,
         "citizen_data": {
             "address": "house",
@@ -1048,14 +983,13 @@ sample_reservations = [
             "name": "Christopher",
             "occupation": "carry",
             "surname": "Smith",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610120937,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610120937,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1428900920,
         "citizen_data": {
             "address": "house",
@@ -1064,14 +998,13 @@ sample_reservations = [
             "name": "Cody",
             "occupation": "midlane",
             "surname": "Oconnell",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610012814,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610012814,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1778987873,
         "citizen_data": {
             "address": "house",
@@ -1080,14 +1013,13 @@ sample_reservations = [
             "name": "Joel",
             "occupation": "soft support",
             "surname": "Robinson",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610204826,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610204826,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1321847439,
         "citizen_data": {
             "address": "house",
@@ -1096,14 +1028,13 @@ sample_reservations = [
             "name": "Faith",
             "occupation": "carry",
             "surname": "Tucker",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609828470,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609828470,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1864067275,
         "citizen_data": {
             "address": "house",
@@ -1112,14 +1043,13 @@ sample_reservations = [
             "name": "Samantha",
             "occupation": "midlane",
             "surname": "Shields",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610403860,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610403860,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1860748884,
         "citizen_data": {
             "address": "house",
@@ -1128,14 +1058,13 @@ sample_reservations = [
             "name": "Angela",
             "occupation": "soft support",
             "surname": "Smith",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609845845,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609845845,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1270677340,
         "citizen_data": {
             "address": "house",
@@ -1144,14 +1073,13 @@ sample_reservations = [
             "name": "Melissa",
             "occupation": "carry",
             "surname": "Morris",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609719568,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609719568,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1777861465,
         "citizen_data": {
             "address": "house",
@@ -1160,14 +1088,13 @@ sample_reservations = [
             "name": "Jonathan",
             "occupation": "carry",
             "surname": "Lewis",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609811561,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609811561,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1107824894,
         "citizen_data": {
             "address": "house",
@@ -1176,14 +1103,13 @@ sample_reservations = [
             "name": "Colleen",
             "occupation": "soft support",
             "surname": "Carey",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609734842,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609734842,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1214485145,
         "citizen_data": {
             "address": "house",
@@ -1192,14 +1118,13 @@ sample_reservations = [
             "name": "Sandra",
             "occupation": "soft support",
             "surname": "Boyd",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610043750,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610043750,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1867586291,
         "citizen_data": {
             "address": "house",
@@ -1208,14 +1133,13 @@ sample_reservations = [
             "name": "Michael",
             "occupation": "offlane",
             "surname": "Griffin",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609863260,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609863260,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1185769336,
         "citizen_data": {
             "address": "house",
@@ -1224,14 +1148,13 @@ sample_reservations = [
             "name": "Jennifer",
             "occupation": "midlane",
             "surname": "Alvarado",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609855545,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609855545,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1163975940,
         "citizen_data": {
             "address": "house",
@@ -1240,14 +1163,13 @@ sample_reservations = [
             "name": "Brenda",
             "occupation": "offlane",
             "surname": "Jones",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609788640,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609788640,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1694760728,
         "citizen_data": {
             "address": "house",
@@ -1256,14 +1178,13 @@ sample_reservations = [
             "name": "Hayden",
             "occupation": "carry",
             "surname": "Conner",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609972972,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609972972,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1197158287,
         "citizen_data": {
             "address": "house",
@@ -1272,14 +1193,13 @@ sample_reservations = [
             "name": "Matthew",
             "occupation": "offlane",
             "surname": "Tran",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610133971,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610133971,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1792680275,
         "citizen_data": {
             "address": "house",
@@ -1288,14 +1208,13 @@ sample_reservations = [
             "name": "Adrian",
             "occupation": "offlane",
             "surname": "Walker",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610341163,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610341163,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1547802924,
         "citizen_data": {
             "address": "house",
@@ -1304,14 +1223,13 @@ sample_reservations = [
             "name": "Sarah",
             "occupation": "soft support",
             "surname": "Hayes",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609994865,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609994865,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1719592778,
         "citizen_data": {
             "address": "house",
@@ -1320,14 +1238,13 @@ sample_reservations = [
             "name": "Jasmin",
             "occupation": "soft support",
             "surname": "Bishop",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610280138,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610280138,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1430653354,
         "citizen_data": {
             "address": "house",
@@ -1336,14 +1253,13 @@ sample_reservations = [
             "name": "Heather",
             "occupation": "carry",
             "surname": "Moore",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609798778,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609798778,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1964807849,
         "citizen_data": {
             "address": "house",
@@ -1352,14 +1268,13 @@ sample_reservations = [
             "name": "Marvin",
             "occupation": "carry",
             "surname": "Davis",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610311277,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610311277,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1630774512,
         "citizen_data": {
             "address": "house",
@@ -1368,14 +1283,13 @@ sample_reservations = [
             "name": "Paul",
             "occupation": "offlane",
             "surname": "Dominguez",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610033126,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610033126,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1459712373,
         "citizen_data": {
             "address": "house",
@@ -1384,14 +1298,13 @@ sample_reservations = [
             "name": "Heather",
             "occupation": "hard support",
             "surname": "Charles",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610397855,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610397855,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1588354921,
         "citizen_data": {
             "address": "house",
@@ -1400,14 +1313,13 @@ sample_reservations = [
             "name": "Daniel",
             "occupation": "hard support",
             "surname": "Moore",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609813080,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609813080,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1699970711,
         "citizen_data": {
             "address": "house",
@@ -1416,14 +1328,13 @@ sample_reservations = [
             "name": "Elizabeth",
             "occupation": "carry",
             "surname": "Schultz",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610418776,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610418776,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1160014675,
         "citizen_data": {
             "address": "house",
@@ -1432,14 +1343,13 @@ sample_reservations = [
             "name": "Charles",
             "occupation": "midlane",
             "surname": "Osborne",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609839600,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609839600,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1019261518,
         "citizen_data": {
             "address": "house",
@@ -1448,14 +1358,13 @@ sample_reservations = [
             "name": "Bryan",
             "occupation": "hard support",
             "surname": "Webb",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610231946,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610231946,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1047456658,
         "citizen_data": {
             "address": "house",
@@ -1464,14 +1373,13 @@ sample_reservations = [
             "name": "Joshua",
             "occupation": "hard support",
             "surname": "Robinson",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609817787,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609817787,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1012082764,
         "citizen_data": {
             "address": "house",
@@ -1480,14 +1388,13 @@ sample_reservations = [
             "name": "Karen",
             "occupation": "midlane",
             "surname": "Hughes",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1610362961,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1610362961,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1812420388,
         "citizen_data": {
             "address": "house",
@@ -1496,14 +1403,13 @@ sample_reservations = [
             "name": "David",
             "occupation": "offlane",
             "surname": "Bryant",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH2",
-        "timestamp":1609761446,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH2",
+        "timestamp": 1609761446,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1271743979,
         "citizen_data": {
             "address": "house",
@@ -1512,14 +1418,13 @@ sample_reservations = [
             "name": "Robert",
             "occupation": "hard support",
             "surname": "Ruiz",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1609836047,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1609836047,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1387545620,
         "citizen_data": {
             "address": "house",
@@ -1528,14 +1433,13 @@ sample_reservations = [
             "name": "Angela",
             "occupation": "offlane",
             "surname": "Williams",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1610404297,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1610404297,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1484428761,
         "citizen_data": {
             "address": "house",
@@ -1544,14 +1448,13 @@ sample_reservations = [
             "name": "Michael",
             "occupation": "hard support",
             "surname": "Mora",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610127020,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610127020,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1195326430,
         "citizen_data": {
             "address": "house",
@@ -1560,14 +1463,13 @@ sample_reservations = [
             "name": "Anthony",
             "occupation": "soft support",
             "surname": "Mullins",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH1",
-        "timestamp":1610278662,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH1",
+        "timestamp": 1610278662,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1259493071,
         "citizen_data": {
             "address": "house",
@@ -1576,14 +1478,13 @@ sample_reservations = [
             "name": "David",
             "occupation": "carry",
             "surname": "Colon",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609907599,
-        "queue":"None"
-    }, {
+        "site_name": "OGYH3",
+        "timestamp": 1609907599,
+        "queue": "None",
+    },
+    {
         "citizen_id": 1411941459,
         "citizen_data": {
             "address": "house",
@@ -1592,12 +1493,10 @@ sample_reservations = [
             "name": "Kyle",
             "occupation": "midlane",
             "surname": "Montoya",
-            "vaccine_taken": [
-
-            ]
+            "vaccine_taken": [],
         },
-        "site_name":"OGYH3",
-        "timestamp":1609929834,
-        "queue":"None"
-    }
+        "site_name": "OGYH3",
+        "timestamp": 1609929834,
+        "queue": "None",
+    },
 ]

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -3,7 +3,7 @@ import requests
 
 def fetch_url(URL, token=""):
     """Return a data that fetch from given url."""
-    r = requests.get(URL, headers={'Authorization': 'Bearer {}'.format(token)})
+    r = requests.get(URL, headers={"Authorization": "Bearer {}".format(token)})
     DATA = r.json()
     return DATA
 
@@ -13,7 +13,7 @@ def arranging_reservation_by_site_name(DATA):
 
     reservations = {}
     for item in DATA:
-        site_name_key = item['site_name']
+        site_name_key = item["site_name"]
         if site_name_key in reservations:
             reservations[site_name_key] = [*reservations[site_name_key], item]
         else:
@@ -26,15 +26,15 @@ def get_cancellation(DATA, citizen_id):
     """Return the user if the citizen id is existed, otherwise return None."""
     for item in DATA.values():
         for user in item:
-            cancel_id = user['citizen_id']
+            cancel_id = user["citizen_id"]
             if cancel_id == citizen_id:
-                user['queue'] = ""
+                user["queue"] = ""
                 return user
     return None
 
 
 def get_service_site_avaliable(data: dict, key: str):
     for i in data:
-        if(key == i):
+        if key == i:
             return i
     return None

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -1,9 +1,9 @@
 import requests
 
 
-def fetch_url(URL):
+def fetch_url(URL, token=""):
     """Return a data that fetch from given url."""
-    r = requests.get(URL)
+    r = requests.get(URL, headers={'Authorization': 'Bearer {}'.format(token)})
     DATA = r.json()
     return DATA
 


### PR DESCRIPTION
# Description
Reservations that exceed the day will assign to the next available day. Walk-in reservations are available when the service site's queue is not full.

## Change
- add capacity to service site.
- compute walk-in queue.
- add query param for reading time slot.
- add DELETE method to remove time slot

## Checklist
- [ ] All test passes?
- [ ] Requires dependency update?
- [ ] Open API easy to read?
- [ ] No bugs and errors when running?
- [ ] Is docstring easy to read?